### PR TITLE
Add include guard

### DIFF
--- a/contour_tracker_lib.h
+++ b/contour_tracker_lib.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cmath>
 #include <math.h>
 #include <assert.h>


### PR DESCRIPTION
Had some errors while compiling, which seem to have been resolved by including a guard, otherwise the same file was included twice.